### PR TITLE
adding missing uvicorn dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.28.2
 segment-anything==1.0
 torch==2.0.1
 transformers
+uvicorn==0.23.2


### PR DESCRIPTION
getting `command not found: uvicorn` when running `sh ./run_opendream.sh` due to missing uvicorn  dep